### PR TITLE
Fix RAUC mark good on sign in complete

### DIFF
--- a/lib/MicroServiceBusHost.js
+++ b/lib/MicroServiceBusHost.js
@@ -214,17 +214,17 @@ function MicroServiceBusHost(settingsHelper) {
         _signInState = "SIGNEDIN";
         microServiceBusNode.SignInComplete(response);
 
-        // log("Marking partition as good".yellow);
-        // let RaucHandler = require('./RaucHandler');
-        // let raucHandler = new RaucHandler();
-        // raucHandler.raucMarkPartitionGood(function (err) {
-        //     if (err) {
-        //         log("Unable to mark partition as good".red + err);
-        //     }
-        //     else {
-        //         log("Successfully marked partition as good...".green);
-        //     }
-        // });
+        log("Marking partition as good".yellow);
+        let RaucHandler = require('./RaucHandler');
+        let raucHandler = new RaucHandler();
+        raucHandler.raucMarkPartition("good", "booted", function (err, slot, msg) {
+            if (err) {
+                log("Unable to mark partition as good".red + err);
+            }
+            else {
+                log(`Successfully ${msg}`.green);
+            }
+        });
 
         _debugModeEnabled = response.debug ? Date.now() : Date.parse('2030-12-31');
 
@@ -672,12 +672,12 @@ function MicroServiceBusHost(settingsHelper) {
         log("Marking partition ".yellow + partition);
         let RaucHandler = require('./RaucHandler');
         let raucHandler = new RaucHandler();
-        raucHandler.raucMarkPartition(partition, function (err) {
+        raucHandler.raucMarkPartition("active", partition, function (err, slot, msg) {
             if (err) {
                 log("Unable to mark partition".red + err);
             }
             else {
-                log("Successfully marked partition. Rebooting...".green);
+                log(`Successfully ${msg}. Rebooting...`.green);
                 _client.invoke('notify', connid, "Successfully marked partition. Rebooting " + settingsHelper.settings.nodeName, "INFO");
                 setTimeout(function () {
                     util.reboot();

--- a/lib/RaucHandler.js
+++ b/lib/RaucHandler.js
@@ -275,7 +275,7 @@ function RaucHandler(){
             }
         );
     };
-    RaucHandler.prototype.raucMarkPartition = function (partition, callback) {
+    RaucHandler.prototype.raucMarkPartition = function (state, partition, callback) {
         const dbus = require('dbus-native');
         var bus = dbus.systemBus();
         const serviceName = 'de.pengutronix.rauc';
@@ -308,57 +308,14 @@ function RaucHandler(){
                 callback(err);
                 return;
             }
-    
-            iface.Mark("active", partition, function (err) {
+            
+            // State = “good”, “bad” or “active”, partition = booted”, “other” or <SLOT_NAME> (e.g. “rootfs.1”)
+            iface.Mark(state, partition, function (err, slot, msg) {
                 if(err){
                     callback(err);
                 }
                 else{
-                    callback();
-                }
-            });
-        });
-    };
-    RaucHandler.prototype.raucMarkPartitionGood = function (callback) {
-        const dbus = require('dbus-native');
-        var bus = dbus.systemBus();
-        const serviceName = 'de.pengutronix.rauc';
-        // The interface we request of the service
-        const interfaceName = 'de.pengutronix.rauc.Installer';
-    
-        // The object we request
-        const objectPath = `/`;
-    
-        // First, connect to the system bus (works the same on the system bus, it's just less permissive)
-        const systemBus = dbus.systemBus();
-    
-        // Check the connection was successful
-        if (!systemBus) {
-            throw new Error('Could not connect to the DBus session bus.');
-        }
-    
-        const service = systemBus.getService(serviceName);
-    
-        this.raucGetProgress();
-        service.getInterface(objectPath, interfaceName, (err, iface) => {
-            if (err) {
-                console.error(
-                    `Failed to request interface '${interfaceName}' at '${objectPath}' : ${
-                        err
-                        }`
-                        ? err
-                        : '(no error)'
-                );
-                callback(err);
-                return;
-            }
-    
-            iface.Mark("good", "booted", function (err) {
-                if(err){
-                    callback(err);
-                }
-                else{
-                    callback();
+                    callback(err, slot, msg);
                 }
             });
         });


### PR DESCRIPTION
Change raucMarkPartition to take slot state as arg, now all functions
of dbus mark method can be used, partition can be marked
“good”, “bad” or “active”. Callback is extended by affected slot and
message describing what has been done.